### PR TITLE
fix default ns-ttl annotation as it could not be applied with kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | (default) keys                                    | value type | value examples |
 |---------------------------------------------------|:-----------:|-------------:|
-|`"utopia-planitia/k8s-gitlab-gc/disable-automatic-garbage-collection"`| string bool | `"true"` (every other string will be evaluated as false) |
-| `"utopia-planitia/k8s-gitlab-gc/ns-ttl-duration"` |  string duration (uses go's ParseDuration function, which means valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.) | `"30m"` or `"2h45m"` |
+|`"k8s-gitlab-gc.utopia-planitia.non-existing-tld/disable-automatic-garbage-collection"`| string bool | `"true"` (every other string will be evaluated as false) |
+| `"k8s-gitlab-gc.utopia-planitia.non-existing-tld/ns-ttl-duration"` |  string duration (uses go's ParseDuration function, which means valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'.) | `"30m"` or `"2h45m"` |
 
-> Note: some name's of keys can be configured (overwritten) via command line flags, e.g. for the `ttlAnnotation` which has a defaukt key like `utopia-planitia/k8s-gitlab-gc/ns-ttl-duration` but can be overwritten
+> Note: some name's of keys can be configured (overwritten) via command line flags, e.g. for the `ttlAnnotation` which has a default key like `k8s-gitlab-gc.utopia-planitia.non-existing-tld/ns-ttl-duration` but can be overwritten

--- a/main.go
+++ b/main.go
@@ -30,8 +30,8 @@ func main() {
 	var maxGitlabExecutorAge = flag.Int64("maxGitlabExecutorAge", 70*60, "max age for gitlab executor pods in seconds")
 	var maxReviewNamespaceAge = flag.Int64("maxReviewNamespaceAge", 60*60*24*2, "max age for review namespaces in seconds")
 	var maxBuildNamespaceAge = flag.Int64("maxBuildNamespaceAge", 60*60*2, "max age for e2e testing namespaces in seconds")
-	var optOutAnnotations = flag.String("optOutAnnotations", "disable-automatic-garbage-collection,utopia-planitia/k8s-gitlab-gc/disable-automatic-garbage-collection", "comma separated list of annotations to protect namespaces from deletion, annotations need to be set to the string 'true'")
-	var ttlAnnotation = flag.String("ttlAnnotation", "utopia-planitia/k8s-gitlab-gc/ns-ttl-duration", "name of the annotation (key) to define the time to life for for the namespace")
+	var optOutAnnotations = flag.String("optOutAnnotations", "disable-automatic-garbage-collection,k8s-gitlab-gc.utopia-planitia.non-existing-tld/disable-automatic-garbage-collection", "comma separated list of annotations to protect namespaces from deletion, annotations need to be set to the string 'true'")
+	var ttlAnnotation = flag.String("ttlAnnotation", "k8s-gitlab-gc.utopia-planitia.non-existing-tld/ns-ttl-duration", "name of the annotation (key) to define the time to life for for the namespace")
 	var onlyUseAgesOf = flag.String("onlyUseAgesOf", "namespace,deployment,statefulset,daemonset,cronjob", fmt.Sprintf("comma separated list of kubernetes resources to use for age evaluation: \"%s\"", strings.Join(keysFrom(availableAgesFuncsMap), ",")))
 
 	flag.Parse()


### PR DESCRIPTION
fix default ns-ttl annotation as it could not be applied with kubectl